### PR TITLE
Change exchangeratesapi.io to exchangerate.host

### DIFF
--- a/workflow/lib/currency/Provider/ExchangeRatesIo.php
+++ b/workflow/lib/currency/Provider/ExchangeRatesIo.php
@@ -14,7 +14,7 @@ class ExchangeRatesIo implements ProviderInterface
      *
      * @var string
      */
-    const EXCHANGERATESIO_API_BASEPATH = 'https://api.exchangeratesapi.io/latest';
+    const EXCHANGERATESIO_API_BASEPATH = 'https://api.exchangerate.host/latest';
 
     /**
      * @var Client


### PR DESCRIPTION
Recently exchangeratesapi.io started requiring an `access_key`
https://github.com/exchangeratesapi/exchangeratesapi/issues/117

However, as described in the discussion above, there are drop-in
replacements that still don't require any access key. This PR uses
one of them.

Tested manually.