### PR TITLE
Input number formatting

### DIFF
--- a/workflow/calculateanything.php
+++ b/workflow/calculateanything.php
@@ -795,12 +795,12 @@ class CalculateAnything
     public function cleanupNumber($number)
     {
         $locale = $this->getSetting('locale_currency', 'en_US');
-        $formatter = new NumberFormatter($locale, NumberFormatter::DECIMAL);
-        $number = $formatter->parse($number);
-        if($number == false) {
-            $formatter = new NumberFormatter('en_US', NumberFormatter::DECIMAL);
-            $number = $formatter->parse($number);
-        }
+        setlocale(LC_NUMERIC, $locale);
+        $locale_format = localeconv();
+        // Set internal decimal point
+        $number = str_replace($locale_format['decimal_point'], '.', $number);
+        // Remove thousand separator
+        $number = str_replace($locale_format['thousands_sep'], '', $number);
         return floatval($number);
     }
 
@@ -836,9 +836,7 @@ class CalculateAnything
             }
         }
 
-        $locale = $this->getSetting('locale_currency', 'en_US');
-        $formatter= new NumberFormatter($locale, NumberFormatter::DECIMAL);
-
-        return $formatter->format($number);
+        $locale_format = localeconv();
+        return number_format($number, $decimals, $locale_format['decimal_point'], $locale_format['thousands_sep']);
     }
 }

--- a/workflow/tools/cryptocurrency.php
+++ b/workflow/tools/cryptocurrency.php
@@ -28,7 +28,7 @@ class Cryptocurrency extends CalculateAnything implements CalculatorInterface
      */
     public function __construct($query)
     {
-        $this->query = str_replace(',', '', $query);
+        $this->query = $query;
         $this->lang = $this->getTranslation('crypto_currency');
         $this->keywords = $this->getKeywords('crypto_currency');
         $this->stop_words = $this->getStopWords('crypto_currency');
@@ -131,7 +131,7 @@ class Cryptocurrency extends CalculateAnything implements CalculatorInterface
         foreach ($checks as $list) {
             $currencies = $this->matchRegex($list);
             $stopwords = $this->getStopWordsString($this->stop_words);
-            preg_match('/^\d*\.?\d+ ?' . $currencies . ' ?' . $stopwords . '?/i', $query, $matches);
+            preg_match('/^[\d,\.]+ ?' . $currencies . ' ?' . $stopwords . '?/i', $query, $matches);
 
             if (!empty($matches)) {
                 $match = true;
@@ -143,7 +143,7 @@ class Cryptocurrency extends CalculateAnything implements CalculatorInterface
             $currencies = $this->matchRegex($list);
             $stopwords = $this->getStopWordsString($this->stop_words);
             $query = $this->query;
-            preg_match('/^\d*\.?\d+ ?' . $currencies . ' ?' . $stopwords . '?/i', $query, $matches);
+            preg_match('/^[\d,\.]+ ?' . $currencies . ' ?' . $stopwords . '?/i', $query, $matches);
 
             if (!empty($matches)) {
                 $match = true;
@@ -439,7 +439,7 @@ class Cryptocurrency extends CalculateAnything implements CalculatorInterface
         $default_currency = self::$currencyCalculator->getBaseCurrency();
         $stopwords = $this->getStopWordsString($this->stop_words, ' %s ');
 
-        preg_match('/^(\d*\.?\d+)[^\d]/i', $query, $amount_match);
+        preg_match('/^([\d,\.]+)[^\d]/i', $query, $amount_match);
         if (empty($amount_match)) {
             return false;
         }

--- a/workflow/tools/currency.php
+++ b/workflow/tools/currency.php
@@ -30,7 +30,7 @@ class Currency extends CalculateAnything implements CalculatorInterface
      */
     public function __construct($query)
     {
-        $this->query = str_replace(',', '', $query);
+        $this->query = $query;
         $this->lang = $this->getTranslation('currency');
         $this->keywords = $this->getKeywords('currency');
         $this->stop_words = $this->getStopWords('currency');
@@ -249,7 +249,7 @@ class Currency extends CalculateAnything implements CalculatorInterface
         $currencies = $this->matchRegex();
         $stopwords = $this->getStopWordsString($this->stop_words);
         
-        return preg_match('/^\d*\.?\d+ ?' . $currencies . ' ?' . $stopwords . '?/i', $query, $matches);
+        return preg_match('/^[\d,\.]+ ?' . $currencies . ' ?' . $stopwords . '?/i', $query, $matches);
     }
 
 
@@ -559,7 +559,7 @@ class Currency extends CalculateAnything implements CalculatorInterface
         $default_currency = $this->getBaseCurrency();
         $stopwords = $this->getStopWordsString($this->stop_words, ' %s ');
 
-        preg_match('/^(\d*\.?\d+)[^\d]/i', $query, $amount_match);
+        preg_match('/^([\d,\.]+)[^\d]/i', $query, $amount_match);
         if (empty($amount_match)) {
             return false;
         }

--- a/workflow/tools/datastorage.php
+++ b/workflow/tools/datastorage.php
@@ -33,7 +33,7 @@ class DataStorage extends CalculateAnything implements CalculatorInterface
      */
     public function __construct($query)
     {
-        $this->query = str_replace(',', '', $query);
+        $this->query = $query;
         $this->lang = $this->getTranslation('datastorage');
         $this->keywords = $this->getKeywords('datastorage');
         $this->stop_words = $this->getStopWords('datastorage');
@@ -82,7 +82,7 @@ class DataStorage extends CalculateAnything implements CalculatorInterface
 
         $query = $this->query;
         $stop_words = $this->stop_words_regex;
-        return preg_match('/^\d*\.?\d+ ?'. $this->match_regex . '\b ?' . $stop_words . '? ?\b' . $this->match_regex . '\b/i', $query, $matches);
+        return preg_match('/[\d,\.]+ ?'. $this->match_regex . '\b ?' . $stop_words . '? ?\b' . $this->match_regex . '\b/i', $query, $matches);
     }
 
 
@@ -97,7 +97,7 @@ class DataStorage extends CalculateAnything implements CalculatorInterface
         $stop_words = $this->stop_words_regex;
         $query = preg_replace("/ ?" . $stop_words . " ?/i", ' ', $query);
         $query = preg_replace('!\s+!', ' ', $query);
-        preg_match('/^(\d*\.?\d+) ?' . $this->match_regex . '\b ?' . $stop_words . '? ?\b' . $this->match_regex . '\b/i', $query, $matches);
+        preg_match('/^([\d,\.]+) ?' . $this->match_regex . '\b ?' . $stop_words . '? ?\b' . $this->match_regex . '\b/i', $query, $matches);
         $matches = array_values(array_filter($matches));
 
         $total_inputs = count($matches);

--- a/workflow/tools/percentage.php
+++ b/workflow/tools/percentage.php
@@ -34,7 +34,6 @@ class Percentage extends CalculateAnything implements CalculatorInterface
     public function shouldProcess(int $strlenght = 0)
     {
         $query = trim($this->query);
-        $query = str_replace(',', '', $query);
 
         if ($strlenght < 3 || !strpos($query, '%')) {
             return false;
@@ -54,7 +53,7 @@ class Percentage extends CalculateAnything implements CalculatorInterface
             $query = str_replace($k, $value, trim($query));
         }
 
-        preg_match('/^(\d*\.?\d*%?)\s?' . $stopwords . '\s?(\d*\.?\d*%?)/i', $query, $matches);
+        preg_match('/^([\d,\.]*%?)\s?' . $stopwords . '\s?([\d,\.]*%?)/i', $query, $matches);
 
         if (empty($matches)) {
             return false;
@@ -251,6 +250,9 @@ class Percentage extends CalculateAnything implements CalculatorInterface
         $pdecrease = ($val2 - $val1) / $val2 * 100;
         $pdecrease = $this->formatNumber($pdecrease);
         $lang = $this->lang;
+
+        $val1 = $this->formatNumber($val1);
+        $val2 = $this->formatNumber($val2);
 
         $values = [];
         $values["{$percentage}%"] = sprintf($lang['result'], $val1, "{$percentage}%", $val2);

--- a/workflow/tools/pxemrem.php
+++ b/workflow/tools/pxemrem.php
@@ -33,7 +33,7 @@ class PXEmRem extends CalculateAnything implements CalculatorInterface
      */
     public function __construct($query)
     {
-        $this->query = str_replace(',', '', $query);
+        $this->query = $query;
         $this->keywords = $this->getKeywords('units');
         $this->stop_words = $this->getStopWords('units');
     }
@@ -53,7 +53,7 @@ class PXEmRem extends CalculateAnything implements CalculatorInterface
         }
 
         $query = $this->query;
-        return preg_match('/^\d*\.?\d+ ?(px|em|rem|pt) ?/', $query, $matches);
+        return preg_match('/^[\d,\.]+ ?(px|em|rem|pt) ?/', $query, $matches);
     }
 
 
@@ -69,7 +69,7 @@ class PXEmRem extends CalculateAnything implements CalculatorInterface
         $query = preg_replace("/ ?" . $stop_words . " ?/i", ' ', $query);
         $query = preg_replace('!\s+!', ' ', $query);
 
-        preg_match('/^(\d*\.?\d+) ?(px|em|rem|pt) ?' . $stop_words . '? ?(px|em|rem|pt)? ?(base.*px$)?/', $query, $matches);
+        preg_match('/^([\d,\.]+) ?(px|em|rem|pt) ?' . $stop_words . '? ?(px|em|rem|pt)? ?(base.*px$)?/', $query, $matches);
         $matches = array_values(array_filter($matches));
 
         $from = 0;

--- a/workflow/tools/units.php
+++ b/workflow/tools/units.php
@@ -34,7 +34,7 @@ class Units extends CalculateAnything implements CalculatorInterface
      */
     public function __construct($query)
     {
-        $this->query = str_replace(',', '', $query);
+        $this->query = $query;
         $this->lang = $this->getTranslation('units');
         $this->keywords = $this->getKeywords('units');
         $this->stop_words = $this->getStopWords('units');
@@ -188,7 +188,7 @@ class Units extends CalculateAnything implements CalculatorInterface
         $stopwords = $this->getStopWordsString($this->stop_words);
         $this->match_units = $units;
 
-        return preg_match('/^\d*\.?\d+ ?' . $units . ' ?' . $stopwords . '? ' . $units . '$/i', $query, $matches);
+        return preg_match('/^([\d,\.]+) ?' . $units . ' ?' . $stopwords . '? ' . $units . '$/i', $query, $matches);
     }
 
 
@@ -347,10 +347,9 @@ class Units extends CalculateAnything implements CalculatorInterface
     private function extractQueryData($query)
     {
         $matches = [];
-        $query = str_replace(',', '', $query);
         $stopwords = $this->getStopWordsString($this->stop_words);
 
-        preg_match('/^(\d*\.?\d+) ?' . $this->match_units . ' ?' . $stopwords . '? ' . $this->match_units . '$/i', $query, $matches);
+        preg_match('/^([\d,\.]+) ?' . $this->match_units . ' ?' . $stopwords . '? ' . $this->match_units . '$/i', $query, $matches);
 
         if (empty($matches)) {
             return false;

--- a/workflow/tools/vat.php
+++ b/workflow/tools/vat.php
@@ -111,16 +111,12 @@ class Vat extends CalculateAnything implements CalculatorInterface
      */
     public function getVatOf($amount)
     {
-        $query = $amount;
-        $percent = $this->percent;
-        $processed = false;
-
-        if (empty($query)) {
-            return $this->output($processed);
+        if (empty($amount)) {
+            return $this->output(false);
         }
 
-        $percent = (float) $percent;
-        $amount = $this->cleanupNumber($query);
+        $percent = (float) $this->percent;
+        $amount = $this->cleanupNumber($amount);
 
         $result = ($percent / 100) * $amount;
         //$result = (fmod($result, 1) !== 0.00 ? bcdiv($result, 1, 2) : $result);

--- a/workflow/tools/vat.php
+++ b/workflow/tools/vat.php
@@ -50,7 +50,7 @@ class Vat extends CalculateAnything implements CalculatorInterface
         $stopwords = '(' . $stopwords . ')';
         $word = strtolower($this->lang['vat']);
 
-        preg_match('/^(\d*\.?\d*) ?' . $stopwords . ' ?' . $word . '$/i', $query, $matches);
+        preg_match('/^([\d,\.]+) ?' . $stopwords . ' ?' . $word . '$/i', $query, $matches);
 
         if (empty($matches)) {
             return false;
@@ -146,7 +146,7 @@ class Vat extends CalculateAnything implements CalculatorInterface
                 ],
                 'plusvat' => [
                     'title' => sprintf($lang['plus'], $amount, $plusvat),
-                    'subtitle' => sprintf($lang['subtitle'], "{$percent}%"),
+                    'subtitle' => sprintf($lang['plus_subtitle'], $amount, "{$percent}%"),
                     'value' => $plusvat
                 ],
                 'minusvat' => [
@@ -192,7 +192,7 @@ class Vat extends CalculateAnything implements CalculatorInterface
                 'mods' => [
                     'cmd' => [
                         'valid' => true,
-                        'arg' => $this->cleanupNumber($value['value']),
+                        'arg' => $value['value'],
                         'subtitle' => $this->lang['cmd'],
                     ]
                 ]


### PR DESCRIPTION
Changed the input number filter from just filtering out `,` to play nice with different ways of writing numbers in different countries. Also changed the output number format function in the same way. Both using PHP's built in class for this: [NumberFormatter](https://www.php.net/manual/en/class.numberformatter.php)

I'm using the existing locale setting used for currency formatting. Either that should change to a general number formatting setting or maybe another one should be added for other number formatting.