### PR TITLE
Add word boundry to unit match regex

### DIFF
--- a/workflow/calculateanything.php
+++ b/workflow/calculateanything.php
@@ -711,7 +711,7 @@ class CalculateAnything
                 continue;
             }
             $key = $this->escapeKeywords($key);
-            $val = preg_replace('/(^|\W)' . $key . '(\W|$)/i', ' ' . $value . ' ', $val);
+            $val = preg_replace('/(^|\W)' . $key . '\b(\W|$)/i', ' ' . $value . ' ', $val);
         }
 
         $val = trim($val);

--- a/workflow/tools/units.php
+++ b/workflow/tools/units.php
@@ -430,13 +430,13 @@ class Units extends CalculateAnything implements CalculatorInterface
         $params_start = [];
         foreach ($units as $value) {
             // $params_start[] = implode(' |', $value);
-            $params_start[] = implode('|', $value);
+            $params_start[] = implode('\b|', $value).'\b';
         }
 
         $translation_keywords = $this->keywords;
         if (!empty($translation_keywords)) {
             // $params_start[] = implode(' |', array_keys($translation_keywords));
-            $params_start[] = implode('|', array_keys($translation_keywords));
+            $params_start[] = implode('\b|', array_keys($translation_keywords)).'\b';
         }
 
         $params_start = implode('|', $params_start);


### PR DESCRIPTION
Add word boundry to avoid matching partial units (i.e. matching nmi as nm)

Fixes https://github.com/biati-digital/alfred-calculate-anything/issues/47