### PR TITLE
To support negative number conversion

### DIFF
--- a/info.plist
+++ b/info.plist
@@ -434,6 +434,56 @@
 				<key>escaping</key>
 				<integer>0</integer>
 				<key>keyword</key>
+				<string>-</string>
+				<key>queuedelaycustom</key>
+				<integer>3</integer>
+				<key>queuedelayimmediatelyinitially</key>
+				<true/>
+				<key>queuedelaymode</key>
+				<integer>0</integer>
+				<key>queuemode</key>
+				<integer>2</integer>
+				<key>runningsubtext</key>
+				<string></string>
+				<key>script</key>
+				<string>$query = "-{query}";
+include_once "./process.php";</string>
+				<key>scriptargtype</key>
+				<integer>0</integer>
+				<key>scriptfile</key>
+				<string></string>
+				<key>subtext</key>
+				<string></string>
+				<key>title</key>
+				<string></string>
+				<key>type</key>
+				<integer>1</integer>
+				<key>withspace</key>
+				<false/>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.input.scriptfilter</string>
+			<key>uid</key>
+			<string>0E49443F-8AF0-464A-803A-1E4B7D11A767</string>
+			<key>version</key>
+			<integer>3</integer>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>alfredfiltersresults</key>
+				<false/>
+				<key>alfredfiltersresultsmatchmode</key>
+				<integer>0</integer>
+				<key>argumenttreatemptyqueryasnil</key>
+				<false/>
+				<key>argumenttrimmode</key>
+				<integer>0</integer>
+				<key>argumenttype</key>
+				<integer>1</integer>
+				<key>escaping</key>
+				<integer>0</integer>
+				<key>keyword</key>
 				<string>0</string>
 				<key>queuedelaycustom</key>
 				<integer>3</integer>

--- a/workflow/calculateanything.php
+++ b/workflow/calculateanything.php
@@ -70,7 +70,8 @@ class CalculateAnything
         // For all calculators that do not require a keyword
         // the passed query must have at leats 3 characters
         // being the first one a number
-        if ($lenght < 3 || !is_numeric($query[0])) {
+        $is_valid_number = $lenght >= 3 && (is_numeric($query[0]) || is_numeric($query[1]));
+        if (!$is_valid_number) {
             return false;
         }
 

--- a/workflow/calculateanything.php
+++ b/workflow/calculateanything.php
@@ -69,7 +69,7 @@ class CalculateAnything
 
         // For all calculators that do not require a keyword
         // the passed query must have at leats 3 characters
-        // being the first one a number
+        // being the first one or second (e.g. -1C) a number
         $is_valid_number = $lenght >= 3 && (is_numeric($query[0]) || is_numeric($query[1]));
         if (!$is_valid_number) {
             return false;

--- a/workflow/tools/units.php
+++ b/workflow/tools/units.php
@@ -218,7 +218,7 @@ class Units extends CalculateAnything implements CalculatorInterface
         $stopwords = $this->getStopWordsString($this->stop_words);
         $this->match_units = $units;
 
-        return preg_match('/^\d*\.?\d+ ?' . $units . ' ?' . $stopwords . '? ' . $units . '$/i', $query, $matches);
+        return preg_match('/^-?\d*\.?\d+ ?' . $units . ' ?' . $stopwords . '? ' . $units . '$/i', $query, $matches);
     }
 
 


### PR DESCRIPTION
# Summary

Temperature values can be negative and converting from Fahrenheit to Celcius (or vice versa) are common use case.
e.g "-25F to C" should return "-31.6C" instead of nothing

- This only affects units-convertor because for other cases negative number handling isn't important

<table>
<tr>
<th>Feature</th>
<th>Demo</th>
</tr>

<tr>
<td>BEFORE: Negative numbers are not converted</td>
<td>
<img src="https://user-images.githubusercontent.com/6264004/221435758-ac71f591-f0c9-4645-8379-f834c25f152b.png" alt="image" />

</td>
</tr>

<tr>
<td>AFTER: Negative numbers are converted
</td>
<td>

<img src="https://user-images.githubusercontent.com/6264004/221435743-063ac988-5ebe-498f-b2a0-f29f14f6a3b3.png" alt="image" />

</td>
</tr>
</table>