### PR TITLE
Add ability to prefix units to currency amounts

### DIFF
--- a/workflow/calculateanything.php
+++ b/workflow/calculateanything.php
@@ -95,6 +95,12 @@ class CalculateAnything
         // the passed query must have at least 3 characters
         // being the first one a number
         if ($lenght < 3 || ($query[0] !== '-' && !is_numeric($query[0])) || ($query[0] === '-' && !is_numeric($query[1]))) {
+            self::$currencyCalculator = new Currency($query);
+            $currency = self::$currencyCalculator;
+            self::$cryptocurrencyCalculator = new Cryptocurrency($query);
+            if($currency->shouldProcess($lenght)){
+                return $currency->processQuery();
+            }
             return false;
         }
 

--- a/workflow/tools/currency.php
+++ b/workflow/tools/currency.php
@@ -249,7 +249,7 @@ class Currency extends CalculateAnything implements CalculatorInterface
         $currencies = $this->matchRegex();
         $stopwords = $this->getStopWordsString($this->stop_words);
 
-        return preg_match('/^([-\d+\.,\s]*) ?' . $currencies . ' ?' . $stopwords . '?/i', $query, $matches);
+        return preg_match('/^' . $currencies . '? ?' . '([-\d+\.,\s]*) ?' . $currencies . '? ?' . $stopwords . '?/i', $query, $matches);
     }
 
 
@@ -541,13 +541,14 @@ class Currency extends CalculateAnything implements CalculatorInterface
         $to = '';
         $default_currency = $this->getBaseCurrency();
         $stopwords = $this->getStopWordsString($this->stop_words, ' %s ');
+        $currencies = $this->matchRegex();
 
-        preg_match('/^([0-9,.\s]+)[^\d]/i', $query, $amount_match);
+        preg_match('/^' . $currencies . '? ?' . '([0-9,.\s]+)/i', $query, $amount_match);
         if (empty($amount_match)) {
             return false;
         }
 
-        $amount = \Alfred\getArgument($amount_match, 1);
+        $amount = \Alfred\getArgument($amount_match, count($amount_match) - 1);
         $amount = trim($amount);
         $string = str_replace($amount, '', $query);
         $string = trim($string);


### PR DESCRIPTION
This can be useful when copying amounts where the `$` or other currency symbol comes before the numeric amount, [as is standard in some countries](https://en.wikipedia.org/wiki/Currency_symbol#Usage)

I did not change the default workflow configuration, so to actually use this, you would have to add a custom keyword to use the workflow, for example, `conv`.

And use it like:

`conv $100 to EUR`

Due to the way the converter works, the following would also work:
`conv USD100 to EUR`

For convenience, we could add all the currency symbols as keywords, but that may not be very maintainable when adding/removing new currencies. But, that would allow queries such as:
`$100` to work automatically