### PR TITLE
Fix comma decimal issues

### DIFF
--- a/workflow/calculateanything.php
+++ b/workflow/calculateanything.php
@@ -173,7 +173,7 @@ class CalculateAnything
      */
     public function processVat()
     {
-        $query = preg_replace('/[^\\d.]+/', '', self::$_query);
+        $query = preg_replace('/[^\d\.,]+/', '', self::$_query);
         $vatCalculator = new Vat($query);
         $data = $vatCalculator->getVatOf($query);
         return $vatCalculator->output($data);

--- a/workflow/tools/units.php
+++ b/workflow/tools/units.php
@@ -457,7 +457,6 @@ class Units extends CalculateAnything implements CalculatorInterface
     private function extractQueryData($query)
     {
         $matches = [];
-        $query = str_replace(',', '', $query);
         $stopwords = $this->getStopWordsString($this->stop_words);
 
         preg_match('/^([-\d+\.,\s]*) ?' . $this->match_units . ' ?' . $stopwords . '? ' . $this->match_units . '$/i', $query, $matches);


### PR DESCRIPTION
At some point (I guess after an update), the workflow stopped properly handling comma-separated decimals for (at least) VAT and unit computation. I applied these changes locally and I did not notice any regressions in my admittedly limited tests.

Thanks!