### PR TITLE
Fixed UK gallon size, closing issue 129

### DIFF
--- a/workflow/tools/units.php
+++ b/workflow/tools/units.php
@@ -103,7 +103,7 @@ class Units extends CalculateAnything implements CalculatorInterface
                     'ukpt' => 0.56826125, //pint
                     'gal' => 3.78541, //gallon
                     'usgal' => 3.78541, //us gallon
-                    'ukgal' => 4.405, //uk gallon
+                    'ukgal' => 4.54609, //uk gallon
                     'qt' => 0.946353, //quart
                     'usqt' => 0.946353, //us quart
                     'ukqt' => 1.1365225, //uk imperial quart


### PR DESCRIPTION
The problem in [issue 129](https://github.com/biati-digital/alfred-calculate-anything/issues/129) is that the UK gallon size was wrong. I've fixed it to 4.54609 litres. With a UK pint being 0.56826125 litres, 8 pints (4,54609 L) matches the gallon.