### PR TITLE
update Fixer API Key field description config window

### DIFF
--- a/info.plist
+++ b/info.plist
@@ -3561,7 +3561,7 @@ If you need help please do not hesitate to open an issue filling all the questio
 				<true/>
 			</dict>
 			<key>description</key>
-			<string>Not mandatory. By default you have access to 32 currencies, If you need access to more than 150 currencies you can add a free API key. It takes less than a minute to get the key from https://fixer.io.</string>
+			<string>Required for currency conversion. A free API key, covering up to 100 requests per month, can be acquired at https://fixer.io.</string>
 			<key>label</key>
 			<string>Fixer API</string>
 			<key>type</key>


### PR DESCRIPTION
[The Fixer API is now used for all currency conversion](https://github.com/biati-digital/alfred-calculate-anything/issues/131) and it requires an API key. The config window still had language referring to the old free alternative API. This PR changes the description to reflect the change and avoid confusion.